### PR TITLE
Bump copyright year to match most recent release

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -93,7 +93,7 @@ Renee Baecker <reneeb@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is Copyright (c) 2016 by Renee Baecker.
+This software is Copyright (c) 2016-2021 by Renee Baecker.
 
 This is free software, licensed under:
 
@@ -105,7 +105,7 @@ Renee Baecker <reneeb@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is Copyright (c) 2016 by Renee Baecker.
+This software is Copyright (c) 2016-2021 by Renee Baecker.
 
 This is free software, licensed under:
 

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Module-OTRS-CoreList
 author  = Renee Baecker <reneeb@cpan.org>
 license = Artistic_2_0
 copyright_holder = Renee Baecker
-copyright_year   = 2016
+copyright_year   = 2016-2021
 
 version = 0.16
 

--- a/lib/Module/OTRS/CoreList.pod
+++ b/lib/Module/OTRS/CoreList.pod
@@ -38,7 +38,7 @@ Renee Baecker <reneeb@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is Copyright (c) 2016 by Renee Baecker.
+This software is Copyright (c) 2016-2021 by Renee Baecker.
 
 This is free software, licensed under:
 


### PR DESCRIPTION
Hi Renee! I hope this change is ok.  I always feel a bit weird suggesting copyright year changes just after the New Year...  If you want, I can set the copyright year to 2021 rather than the year of the most recent release; just let me know and I'll update the PR and resubmit.