### PR TITLE
Install author testing dependency for Test2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
    # Deal with all of the DZIL dependancies, quickly and quietly
 
    - cpanm --quiet --notest --skip-satisfied Dist::Zilla
+   - cpanm --quiet Term::Table
 
    - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
 


### PR DESCRIPTION
... so that builds on Travis-CI work again.

It turned out that `Test2` needs `Term::Table` in order for its tests to pass, which is a dependency installed as part of the `authordeps` step when installing prerequisites for Travis-CI.  This patch adds the missing dependency and now the tests pass on Travis.  If this is the incorrect place to put this dependency, please let me know and I'll update the patch and resubmit.