### PR TITLE
Set minimum Perl version explicitly

### DIFF
--- a/scripts/get_modules.pl
+++ b/scripts/get_modules.pl
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use 5.008;
 
 use Archive::Tar;
 use Clone qw(clone);

--- a/t/001_basic_tests.t
+++ b/t/001_basic_tests.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use 5.008;
 use Test::More;
 
 use File::Basename;


### PR DESCRIPTION
The minimum Perl version found by `Perl::MinimumVersion` was actually
version 5.6, however I checked the OTRS 2.3 admin manual and it
recommended using Perl 5.8+, hence I've used this for the explicitly
specified minimum Perl version.